### PR TITLE
generated_header: add missing stddef include

### DIFF
--- a/include/cnkalman/generated_header.h
+++ b/include/cnkalman/generated_header.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stddef.h>
 #include <math.h>
 static inline double __cnkalman_safe_sqrt(double x) { return x > 0 ? sqrt(x) : 0; }
 #define sqrt __cnkalman_safe_sqrt


### PR DESCRIPTION
Missing `stddef` include leading to a lot of compilation errors related to `offsetof`

```
/home/simon/src/libsurvive/src/generated/kalman_kinematics.gen.h: In function 'SurviveKalmanErrorModel_LightMeas_y_gen2_jac_bsc0':
/home/simon/src/libsurvive/src/generated/kalman_kinematics.gen.h:13599:45: error: expected expression before 'BaseStationCal'
13599 |         cnMatrixOptionalSet(Hx, 0, offsetof(BaseStationCal, curve)/sizeof(FLT), (-1 * x82 * x84) + (-1 * x82));
      |                                             ^~~~~~~~~~~~~~
/home/simon/src/libsurvive/src/generated/kalman_kinematics.gen.h:13600:45: error: expected expression before 'BaseStationCal'
13600 |         cnMatrixOptionalSet(Hx, 0, offsetof(BaseStationCal, gibmag)/sizeof(FLT), sin(x83));
      |                                             ^~~~~~~~~~~~~~before 'BaseStationCal'
13601 |         cnMatrixOptionalSet(Hx, 0, offsetof(BaseStationCal, gibpha)/sizeof(FLT), x84);
      |                                             ^~~~~~~~~~~~~~
[ 41%] Building C object src/CMakeFiles/survive.dir/survive_process_gen1.c.o
/home/simon/src/libsurvive/src/generated/kalman_kinematics.gen.h:13602:45: error: expected expression before 'BaseStationCal'
13602 |         cnMatrixOptionalSet(Hx, 0, offsetof(BaseStationCal, ogeemag)/sizeof(FLT), (-1 * x84 * x85) + (-1 * x85));
      |                                             ^~~~~~~~~~~~~~
/home/simon/src/libsurvive/src/generated/kalman_kinematics.gen.h:13603:45: error: expected expression before 'BaseStationCal'
13603 |         cnMatrixOptionalSet(Hx, 0, offsetof(BaseStationCal, ogeephase)/sizeof(FLT), (-1 * x88 * x84) + (-1 * x88));
      |                                             ^~~~~~~~~~~~~~
/home/simon/src/libsurvive/src/generated/kalman_kinematics.gen.h:13604:45: error: expected expression before 'BaseStationCal'
13604 |         cnMatrixOptionalSet(Hx, 0, offsetof(BaseStationCal, phase)/sizeof(FLT), -1);
      |                                             ^~~~~~~~~~~~~~
/home/simon/src/libsurvive/src/generated/kalman_kinematics.gen.h:13605:45: error: expected expression before 'BaseStationCal'
13605 |         cnMatrixOptionalSet(Hx, 0, offsetof(BaseStationCal, tilt)/sizeof(FLT), (-1 * x84 * x98) + (-1 * x98));

```